### PR TITLE
Separate CSS of use cases boxes and headers

### DIFF
--- a/landing-pages/site/assets/scss/_list-boxes.scss
+++ b/landing-pages/site/assets/scss/_list-boxes.scss
@@ -139,6 +139,33 @@ $card-margin: 20px;
     }
   }
 
+
+  &__use-cases {
+    padding: 18px 18px 0;
+    justify-content: space-between;
+
+    &--logo {
+      display: flex;
+      height: 60px;
+      width:100%;
+      justify-content: center;
+      align-items: center;
+
+      svg, img {
+        max-height: 100%;
+        max-width: 100%;
+      }
+    }
+
+    &--usecasedescription {
+      @extend .bodytext__medium--brownish-grey;
+      font-style: normal;
+      margin: 30px 0 20px;
+      text-align: center;
+    }
+  }
+
+
   &__committer {
     &--nick {
       @extend .bodytext__medium--greyish-brown;

--- a/landing-pages/site/assets/scss/_usecasedescription.scss
+++ b/landing-pages/site/assets/scss/_usecasedescription.scss
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+@import "colors";
+@import "media";
+
+.usecasedescription {
+  display: flex;
+  flex-direction: column;
+  border-bottom: solid 1px map-get($colors, very-light-pink);
+  padding: 0 78px 60px;
+
+  &--text {
+    @extend .subtitle__large--brownish-grey;
+    text-align: center;
+    font-weight: normal;
+
+  }
+
+  &--author {
+    @extend .bodytext__medium--greyish-brown;
+    text-align: center;
+    font-weight: 500;
+    margin-bottom: 32px;
+  }
+
+  &--logo {
+    max-height: 140px;
+    margin: 0 auto;
+  }
+}
+
+@media (max-width: $mobile) {
+  .usecasedescription {
+    padding: 0 0 40px;
+  }
+}

--- a/landing-pages/site/assets/scss/main-custom.scss
+++ b/landing-pages/site/assets/scss/main-custom.scss
@@ -28,6 +28,7 @@
 @import "list-boxes";
 @import "avatar";
 @import "quote";
+@import "usecasedescription";
 @import "pager";
 @import "case-study";
 @import "markdown-content";

--- a/landing-pages/site/content/en/use-cases/business_operations.md
+++ b/landing-pages/site/content/en/use-cases/business_operations.md
@@ -1,7 +1,7 @@
 ---
 title: "Business Operations"
 linkTitle: "Business Operations"
-quote:
+usecasedescription:
     text: "Many companies build their core business, data powered applications, on top of Apache Airflow."
 logo: "business-ops.png"
 blocktype: use-case

--- a/landing-pages/site/content/en/use-cases/etl_analytics.md
+++ b/landing-pages/site/content/en/use-cases/etl_analytics.md
@@ -1,7 +1,7 @@
 ---
 title: "ETL/ELT"
 linkTitle: "ETL/ELT"
-quote:
+usecasedescription:
     text: "Airflow is the open source standard for orchestrating ETL/ELT data pipelines."
 logo: "etl.png"
 blocktype: use-case

--- a/landing-pages/site/content/en/use-cases/infrastructure-management.md
+++ b/landing-pages/site/content/en/use-cases/infrastructure-management.md
@@ -37,6 +37,6 @@ Airflow is a popular choice for pipelines that require managing infrastructure b
 
 ## Airflow features for Infrastructure Management
 
-Airflow has several key features that make it a great option for managing infrastructure:
+Airflow 2.7 implemented a new key feature that makes it an even greater option for managing infrastructure:
 
-- [**Setup/teardown tasks**](https://airflow.apache.org/docs/apache-airflow/stable/howto/setup-and-teardown.html): Setup/ teardown tasks are a special type of task that can be used to manage the infrastructure needed to run other tasks. They have special behavior to support the pattern of setting up resources and configuration (e.g. a Spark cluster or other compute resources) before a task runs, and then tearing down that infrastructure after the task has completed, even if the task fails.
+- [**Setup/teardown tasks**](https://airflow.apache.org/docs/apache-airflow/stable/howto/setup-and-teardown.html): Setup/teardown tasks are a special type of task that can be used to manage the infrastructure needed to run other tasks. They have special behavior to support the pattern of setting up resources and configuration (e.g. a Spark cluster or other compute resources) before a task runs, and then tearing down that infrastructure after the task has completed, even if the task fails.

--- a/landing-pages/site/content/en/use-cases/infrastructure-management.md
+++ b/landing-pages/site/content/en/use-cases/infrastructure-management.md
@@ -1,7 +1,7 @@
 ---
 title: "Infrastructure Management"
 linkTitle: "Infrastructure Management"
-quote:
+usecasedescription:
     text: "With Airflow you can spin up, manage and tear down your infrastructure at the exact time you need it."
 logo: "infrastructure-management.png"
 blocktype: use-case

--- a/landing-pages/site/content/en/use-cases/mlops.md
+++ b/landing-pages/site/content/en/use-cases/mlops.md
@@ -1,7 +1,7 @@
 ---
 title: "MLOps"
 linkTitle: "MLOps"
-quote:
+usecasedescription:
     text: "Airflow is the heart of the modern MLOps stack, orchestrating the entire machine learning lifecycle."
 logo: "mlops.png"
 blocktype: use-case

--- a/landing-pages/site/layouts/partials/boxes/use-cases.html
+++ b/landing-pages/site/layouts/partials/boxes/use-cases.html
@@ -19,14 +19,14 @@
    
    {{ $title := .title }}
    <div class="card">
-       <div class="box-event box-event__case-study hoverable-icon">
-           <div class="box-event__case-study--logo">
+       <div class="box-event box-event__use-cases hoverable-icon">
+           <div class="box-event__use-cases--logo">
                {{ with .logo }}
                    <img src="/usecase-logos/{{ . }}" alt="{{ $title }} logo" />
                {{ end }}
            </div>
-           <p class="box-event__case-study--quote"
-              >{{ .quote.text | truncate 120 }}</p>
+           <p class="box-event__use-cases--usecasedescription"
+              >{{ .usecasedescription.text | truncate 120 }}</p>
            {{ partial "buttons/button-hollow" (dict "text" "Learn more")}}
        </div>
    </div>

--- a/landing-pages/site/layouts/partials/boxes/use-cases.html
+++ b/landing-pages/site/layouts/partials/boxes/use-cases.html
@@ -1,33 +1,33 @@
 {{/*
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-   
-      http://www.apache.org/licenses/LICENSE-2.0
-   
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-   */}}
-   
-   {{ $title := .title }}
-   <div class="card">
-       <div class="box-event box-event__use-cases hoverable-icon">
-           <div class="box-event__use-cases--logo">
-               {{ with .logo }}
-                   <img src="/usecase-logos/{{ . }}" alt="{{ $title }} logo" />
-               {{ end }}
-           </div>
-           <p class="box-event__use-cases--usecasedescription"
-              >{{ .usecasedescription.text | truncate 120 }}</p>
-           {{ partial "buttons/button-hollow" (dict "text" "Learn more")}}
-       </div>
-   </div>
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
+
+{{ $title := .title }}
+<div class="card">
+    <div class="box-event box-event__use-cases hoverable-icon">
+        <div class="box-event__use-cases--logo">
+            {{ with .logo }}
+                <img src="/usecase-logos/{{ . }}" alt="{{ $title }} logo" />
+            {{ end }}
+        </div>
+        <p class="box-event__use-cases--usecasedescription"
+            >{{ .usecasedescription.text | truncate 120 }}</p>
+        {{ partial "buttons/button-hollow" (dict "text" "Learn more")}}
+    </div>
+</div>
    

--- a/landing-pages/site/layouts/partials/usecasedescription.html
+++ b/landing-pages/site/layouts/partials/usecasedescription.html
@@ -17,15 +17,11 @@
  under the License.
 */}}
 
-<div class="td-content">
-    {{ if .Params.quote }}
-      {{ partial "quote" .Params }}
-    {{ else if .Params.usecasedescription }}
-      {{ partial "usecasedescription" .Params }}
+{{ $title := .title }}
+<div class="usecasedescription">
+    <p class="usecasedescription--text">{{ .usecasedescription.text }}</p>
+    <p class="usecasedescription--author">{{ .usecasedescription.author }}</p>
+    {{ with .logo }}
+        <img src="/usecase-logos/{{ . }}" alt="{{ $title }} logo" class="usecasedescription--logo" />
     {{ end }}
-    {{ with .Params.description }}
-    <div class="lead">{{ . | markdownify }}</div>{{ end }}
-    <div class="markdown-content">
-        {{ .Content }}
-    </div>
 </div>

--- a/landing-pages/src/index.js
+++ b/landing-pages/src/index.js
@@ -40,7 +40,7 @@ showMore("#pmc-container", "#show-more-pmcs", 4);
 showMore(
   "#testimonials-container",
   "#show-more-testimonials",
-  5);
+  4);
 
 handleActiveVideo();
 


### PR DESCRIPTION
Removes the quotes and italics plus a small copy edit and setting the testimonials shown from 5 to 4 so they all fit on one line.